### PR TITLE
ci: request reviews on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "yuyuyuyuyu-dev"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "yuyuyuyuyu-dev"


### PR DESCRIPTION
## Summary
- Add `reviewers` to both `gradle` and `github-actions` entries in `.github/dependabot.yml` so Dependabot sends a review request to the maintainer on every update PR.
- This makes Dependabot PRs easier to find and triage in one place using GitHub's `review-requested:@me` filter, instead of relying on per-PR notifications alone.

## Notes
- The existing `main` branch ruleset does not require PR reviews, so this change has no effect on merge requirements — it is purely for routing/visibility.
- Only applies to Dependabot PRs opened after this change is merged; existing open PRs are unaffected.

## Post-merge verification
- [ ] On the next Dependabot run, confirm a review request is sent for both ecosystems (gradle, github-actions).
- [ ] Verify the resulting PR appears under the `review-requested:@me` filter in the Pull requests tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)