### PR TITLE
feat: add JVM desktop target

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.google.devtools.ksp.gradle.KspAATask
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -15,6 +16,12 @@ plugins {
 
 kotlin {
     androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+
+    jvm {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }
@@ -67,10 +74,25 @@ kotlin {
             implementation(libs.yuyuyuyuyu.myMaterialTheme)
             implementation(libs.yuyuyuyuyu.siimpleTopAppBar)
         }
+        jvmMain.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
+        }
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "dev.yuyuyuyuyu.howoldami.MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageName = "dev.yuyuyuyuyu.howoldami"
+            packageVersion = "1.0.0"
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/howoldami/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/howoldami/Main.kt
@@ -1,0 +1,14 @@
+package dev.yuyuyuyuyu.howoldami
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+
+fun main() =
+    application {
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "How Old Am I",
+        ) {
+            App()
+        }
+    }

--- a/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/howoldami/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/howoldami/Platform.jvm.kt
@@ -1,0 +1,7 @@
+package dev.yuyuyuyuyu.howoldami
+
+class JvmPlatform : Platform {
+    override val name: String = "Java ${System.getProperty("java.version")}"
+}
+
+actual fun getPlatform(): Platform = JvmPlatform()


### PR DESCRIPTION
## Summary
- Adds a Kotlin/JVM target to `composeApp` so the app can launch as a Compose for Desktop application alongside the existing Android, JS, and Wasm targets.
- Wires up `compose.desktop` with `Dmg`, `Msi`, and `Deb` native distribution formats and adds the desktop entry point (`Main.kt`) plus the JVM `Platform` actual.

## Test plan
- [x] `./gradlew :composeApp:compileKotlinJvm` succeeds
- [x] `./gradlew :composeApp:jvmJar` succeeds
- [x] `./gradlew :composeApp:spotlessCheck :composeApp:detekt` passes
- [x] `./gradlew :composeApp:run` launches the desktop window
- [x] `./gradlew :composeApp:packageDistributionForCurrentOS` produces a working native installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)