### PR TITLE
ci: auto-update yarn.lock on Dependabot dependency bumps

### DIFF
--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -1,0 +1,78 @@
+name: Update yarn.lock
+
+# Keeps kotlin-js-store/yarn.lock in sync on Dependabot dependency bumps.
+#
+# Why this exists:
+#   The `Run Tests` job (`./gradlew allTests`) runs `:kotlinStoreYarnLock`, which
+#   FAILS when a fresh dependency resolution differs from the committed lock.
+#   A dependency bump (e.g. Kotlin) changes the Gradle cache key, so CI re-resolves
+#   the JS yarn offline mirror from scratch and can pick up newer transitive patch
+#   versions than the committed lock, breaking unrelated Dependabot PRs.
+#
+# This workflow regenerates the lock and pushes it back to the PR branch so the
+# committed lock stays authoritative (instead of silencing the check).
+#
+# One-time setup required:
+#   Create a fine-grained Personal Access Token scoped to THIS repo with
+#   `Contents: Read and write`, and add it as a *Dependabot* secret named
+#   `YARN_LOCK_PAT` (Settings -> Secrets and variables -> Dependabot).
+#   A PAT (not the default GITHUB_TOKEN) is required because pushes made with
+#   GITHUB_TOKEN do not re-trigger CI on the new commit.
+#   Without the secret the job is a no-op (it only warns).
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "gradle/libs.versions.toml"
+
+# Avoid overlapping auto-updates on the same PR.
+concurrency:
+  group: update-yarn-lock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-yarn-lock:
+    name: Update yarn.lock
+    # Only Dependabot PRs, whose head branches live in this repo and can be pushed to.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'jetbrains'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Regenerate yarn.lock
+        run: ./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock
+
+      - name: Commit and push if changed
+        env:
+          # Exposed only to this step to keep it out of the Gradle build environment.
+          GH_PAT: ${{ secrets.YARN_LOCK_PAT }}
+        run: |
+          if [ -z "$(git status --porcelain kotlin-js-store)" ]; then
+            echo "yarn.lock already up to date - nothing to do."
+            exit 0
+          fi
+          if [ -z "${GH_PAT}" ]; then
+            echo "::warning::kotlin-js-store/yarn.lock is out of date but no YARN_LOCK_PAT secret is configured; skipping auto-commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add kotlin-js-store
+          git commit -m 'build: actualize yarn.lock for dependency bump'
+          git push "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_HEAD_REF}"


### PR DESCRIPTION
## Why

Dependency bumps from Dependabot (notably Kotlin) break the `Run Tests` job
(`:kotlinStoreYarnLock`, run by `./gradlew allTests`) because of **yarn.lock
drift** — as seen in #47.

When a bump changes the Gradle cache key, CI cannot restore the cached yarn
offline mirror, re-resolves the JS dependency tree against the live npm
registry, and picks up newer transitive patch versions than the committed
`kotlin-js-store/yarn.lock`. The store task then reports a mismatch and fails,
blocking otherwise-fine Dependabot PRs.

## What this PR does

Adds `.github/workflows/update-yarn-lock.yml`. On a Dependabot PR that touches
`gradle/libs.versions.toml`, it:

1. Regenerates the lock via `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock`.
2. Commits and pushes the refreshed `kotlin-js-store/` back to the PR branch if
   anything changed.

This keeps the committed lock **authoritative** (rather than weakening the
check), and is a no-op when nothing changed.

## ⚠️ One-time setup required after merge

The job needs a PAT to actually push, because commits pushed with the default
`GITHUB_TOKEN` do **not** re-trigger CI on the new commit.

1. Create a **fine-grained PAT** scoped to this repository with
   `Contents: Read and write`.
2. Add it as a **Dependabot** secret (Settings → Secrets and variables →
   **Dependabot** → New repository secret) named `YARN_LOCK_PAT`.

> Until the secret exists the workflow is a safe no-op: it only emits a warning
> when the lock is stale. Once configured, it auto-updates the lock and CI
> re-runs on the new commit.

## Security considerations

- Runs only for `github.actor == 'dependabot[bot]'` PRs.
- The PAT is injected only into the push step's `env`, never into the Gradle
  build environment.
- The default `GITHUB_TOKEN` permission is limited to `contents: read`.
- Does not use `pull_request_target`, so PR code is never run with secrets.

## Alternative considered

Relaxing `yarnLockMismatchReport` to `WARNING` (a smaller change) would also stop
the failures, but it loosens the lock's audit/reproducibility guarantee. This PR
keeps the lock authoritative by regenerating it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)