### PR TITLE
ci: run the production build in CI to match deploy

### DIFF
--- a/.github/actions/build-distribution/action.yml
+++ b/.github/actions/build-distribution/action.yml
@@ -1,0 +1,25 @@
+name: Build distribution
+description: >
+  Sets up the JDK/Gradle toolchain and builds the production Wasm/JS browser
+  distribution. Shared by the CI build check and the deploy job so both run the
+  exact same build, preventing a build break from surfacing only at deploy time.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'jetbrains'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+
+    - name: Export Library Definitions
+      shell: bash
+      run: ./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/
+
+    - name: Build
+      shell: bash
+      run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,16 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Run Tests
         run: ./gradlew allTests
+
+  build:
+    name: Build Distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      # Runs the exact same build as the deploy job (see .github/actions/build-distribution)
+      # so a broken production build is caught on the pull request, not after merging to main.
+      - name: Build distribution
+        uses: ./.github/actions/build-distribution

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   workflow_run:
-    workflows: [ Tests ]
+    workflows: [ CI ]
     types: [ completed ]
     branches: [ main ]
 
@@ -22,20 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Export Library Definitions
-        run: ./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/
-
-      - name: Build
-        run: ./gradlew :composeApp:wasmJsBrowserDistribution
+      # Shared with the CI build check (see .github/actions/build-distribution) so
+      # deploy and CI always run the exact same build.
+      - name: Build distribution
+        uses: ./.github/actions/build-distribution
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary

CI only ran `spotlessCheck`, `detekt` and `allTests`, while the **Deploy** workflow produced the actual GitHub Pages artifact via `exportLibraryDefinitions` + `wasmJsBrowserDistribution`. Because the production build was never exercised in CI, a build break could pass all checks, get merged into `main`, and only surface when the deploy tried (and failed) to build it.

This change makes CI run the **exact same build** as deploy, so a broken production build is caught on the pull request instead of after merging.

## Changes

- **Share one build definition.** Extract the deploy build into a composite action (`.github/actions/build-distribution`) that sets up the JDK/Gradle toolchain and runs `exportLibraryDefinitions` + `wasmJsBrowserDistribution`. Both CI and deploy now call it, so the two can never drift apart.
- **Build on every PR.** Add a `Build Distribution` job to the CI workflow so the production build runs on every pull request and `main` push.
- **Fix a broken deploy trigger (bug found along the way).** Deploy is gated on `workflow_run` of a workflow named `Tests`, but that workflow was renamed to `CI` in commit 42ee6d7. The stale name meant the trigger matched nothing, so deploys silently stopped firing. Point `workflow_run.workflows` at `CI`.

## Test plan

- [x] Ran the deploy build locally: `./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/` followed by `./gradlew :composeApp:wasmJsBrowserDistribution` → `BUILD SUCCESSFUL`, no generated-file drift.
- [x] The new `Build Distribution` job runs and passes on this PR's checks.
- [x] The existing `Check Formatting`, `Static Analysis`, and `Run Tests` jobs still pass on this PR.

## Notes

The deploy-trigger fix can only be fully observed after this lands on `main` (deploy runs on push to `main`): the next merge should trigger the `Deploy` workflow once `CI` completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)