### PR TITLE
chore(deps): limit Dependabot open PRs to 1 and drop deprecated reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
-    reviewers:
-      - "yuyuyuyuyu-dev"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
-    reviewers:
-      - "yuyuyuyuyu-dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
     reviewers:
       - "yuyuyuyuyu-dev"
 
@@ -11,5 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
     reviewers:
       - "yuyuyuyuyu-dev"


### PR DESCRIPTION
## What
- Set `open-pull-requests-limit: 1` on each Dependabot update entry (gradle, github-actions).
- Remove the deprecated `reviewers` field. Reviewer assignment is handled by `.github/CODEOWNERS` (`* @yuyuyuyuyu-dev`).

## Why
- **PR limit:** this repo requires branches to be up to date with `main` before merging. When Dependabot opens several PRs at once, only one can be merged; the rest must be rebased and the CI that ran on them in parallel is wasted. Capping open PRs at 1 avoids that.
- **reviewers:** the `reviewers` key is deprecated for Dependabot; CODEOWNERS already covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)