### PR TITLE
build: enforce version catalog formatting with version-catalog-update plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Run Spotless
         run: ./gradlew spotlessCheck
+      - name: Check version catalog formatting
+        # `versionCatalogFormat` rewrites gradle/libs.versions.toml in place, so a
+        # dirty working tree afterwards means the committed catalog was not formatted.
+        # Run `./gradlew versionCatalogFormat` locally and commit the result to fix.
+        run: |
+          ./gradlew versionCatalogFormat
+          git diff --exit-code gradle/libs.versions.toml
 
   linting:
     name: Static Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Run Spotless
         run: ./gradlew spotlessCheck
       - name: Check version catalog formatting
-        # `versionCatalogFormat` rewrites gradle/libs.versions.toml in place, so a
-        # dirty working tree afterwards means the committed catalog was not formatted.
-        # Run `./gradlew versionCatalogFormat` locally and commit the result to fix.
+        # The format task has no check-only mode, so we format and treat any
+        # resulting diff as proof the committed catalog was not formatted.
         run: |
           ./gradlew versionCatalogFormat
           git diff --exit-code gradle/libs.versions.toml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.versionCatalogUpdate)
 }
 
 allprojects {
@@ -28,4 +29,11 @@ allprojects {
 detekt {
     config.setFrom(file("${project.rootDir}/config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
+}
+
+// Keeps gradle/libs.versions.toml consistently sorted and formatted.
+// Run `./gradlew versionCatalogFormat` to apply the canonical layout;
+// CI runs the same task and fails if the file is not already formatted.
+versionCatalogUpdate {
+    sortByKey = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,10 @@ detekt {
     buildUponDefaultConfig = true
 }
 
-// Keeps gradle/libs.versions.toml consistently sorted and formatted.
-// Run `./gradlew versionCatalogFormat` to apply the canonical layout;
-// CI runs the same task and fails if the file is not already formatted.
+// Gradle has no built-in formatter for version catalogs and Spotless does not
+// cover them yet, so this plugin is what keeps libs.versions.toml diffs small
+// and review-focused instead of leaving entry order to manual bikeshedding.
 versionCatalogUpdate {
+    // Deterministic ordering so unrelated dependency edits don't collide.
     sortByKey = true
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,50 +1,52 @@
 [versions]
-androidx-lifecycle = "2.11.0-beta02"
-composeMultiplatform = "1.12.0-alpha02"
-kotlin = "2.4.0"
-material3 = "1.12.0-alpha02"
-datetime = "0.8.0-rc02-0.6.x-compat"
 aboutLibraries = "15.0.2"
-ksp = "2.3.9"
-kotlinInject = "0.9.0"
+androidx-lifecycle = "2.11.0-beta02"
 compose-multiplatform-adaptive = "1.3.0-beta02"
 compose-multiplatform-lifecycle = "2.11.0-beta02"
-multiplatform-nav3-ui = "1.1.1"
-kotlinxSerialization = "1.11.0"
+composeMultiplatform = "1.12.0-alpha02"
 composePwa = "0.6.1"
+datetime = "0.8.0-rc02-0.6.x-compat"
+detekt = "1.23.8"
+kotlin = "2.4.0"
+kotlinInject = "0.9.0"
+kotlinxSerialization = "1.11.0"
+ksp = "2.3.9"
+material3 = "1.12.0-alpha02"
+multiplatform-nav3-ui = "1.1.1"
 myMaterialTheme = "0.4.0"
 simpleTopAppBar = "0.4.0"
 spotless = "8.8.0"
-detekt = "1.23.8"
+versionCatalogUpdate = "1.1.0"
 
 [libraries]
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
+androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
-compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
-aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }      # Material 3 UI
-kotlinInject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlinInject" }
-kotlinInject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlinInject" }
 jetbrains-lifecycle-viewmodelNavigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "compose-multiplatform-lifecycle" }
 jetbrains-material3-adaptiveNavigation3 = { module = "org.jetbrains.compose.material3.adaptive:adaptive-navigation3", version.ref = "compose-multiplatform-adaptive" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "multiplatform-nav3-ui" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinInject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlinInject" }
+kotlinInject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlinInject" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-yuyuyuyuyu-myMaterialTheme = { group = "dev.yuyuyuyuyu", name = "mymaterialtheme", version.ref = "myMaterialTheme" }
-yuyuyuyuyu-siimpleTopAppBar = { group = "dev.yuyuyuyuyu", name = "simpletopappbar", version.ref = "myMaterialTheme" }
+yuyuyuyuyu-myMaterialTheme = { module = "dev.yuyuyuyuyu:mymaterialtheme", version.ref = "myMaterialTheme" }
+yuyuyuyuyu-siimpleTopAppBar = { module = "dev.yuyuyuyuyu:simpletopappbar", version.ref = "simpleTopAppBar" }
 
 [plugins]
-composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
+aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
+composePwa = { id = "dev.yuyuyuyuyu.composepwa", version.ref = "composePwa" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-composePwa = { id = "dev.yuyuyuyuyu.composepwa", version.ref = "composePwa" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdate" }


### PR DESCRIPTION
Adopt Little Robots' version-catalog-update plugin, the de-facto standard
for linting and formatting Gradle version catalogs, and enforce it in CI so
gradle/libs.versions.toml stays canonically sorted and normalized.

- Apply nl.littlerobots.version-catalog-update 1.1.0 at the root build,
  configured with sortByKey so every table is ordered alphabetically.
- Reformat gradle/libs.versions.toml: sort all tables by key and rewrite
  library coordinates to the short `module = "group:name"` form.
- Fix a latent reference bug the formatter surfaced: yuyuyuyuyu-siimpleTopAppBar
  now points at the simpleTopAppBar version instead of myMaterialTheme, so the
  two libraries can version independently.
- Add a CI step that runs `versionCatalogFormat` and fails if it produces a
  diff, keeping the catalog formatted on every pull request.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LWFWrbwcg2u1BtHoFAMcDe