### PR TITLE
build: format non-Kotlin files with Prettier via Spotless

### DIFF
--- a/.github/actions/build-distribution/action.yml
+++ b/.github/actions/build-distribution/action.yml
@@ -10,8 +10,8 @@ runs:
     - name: Setup JDK
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
-        distribution: 'jetbrains'
+        java-version: "21"
+        distribution: "jetbrains"
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   formatting:
@@ -18,8 +18,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run Spotless
@@ -42,8 +42,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run Detekt
@@ -60,8 +60,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run Tests

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,9 +2,9 @@ name: Dependabot
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   dependabot:
@@ -19,8 +19,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Send dependencies to Dependabot
         uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@ name: Deploy
 
 on:
   workflow_run:
-    workflows: [ CI ]
-    types: [ completed ]
-    branches: [ main ]
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   deploy:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write    # to deploy to Pages
+      pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages

--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -22,7 +22,7 @@ name: Update yarn.lock
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - "gradle/libs.versions.toml"
 
@@ -49,8 +49,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Deploy](https://github.com/yuyuyuyuyu-dev/how-old-am-i/actions/workflows/deploy.yml/badge.svg)](https://github.com/yuyuyuyuyu-dev/how-old-am-i/actions/workflows/deploy.yml)
 [![CI](https://github.com/yuyuyuyuyu-dev/how-old-am-i/actions/workflows/ci.yml/badge.svg)](https://github.com/yuyuyuyuyu-dev/how-old-am-i/actions/workflows/ci.yml)
 
-生年月日から年齢を計算するWebアプリ
+生年月日から年齢を計算する Web アプリ
 
 <a href="https://how-old-am-i.yuyuyuyuyu.dev" target="_blank" rel="noopener noreferrer">https://how-old-am-i.yuyuyuyuyu.dev</a><br />
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,26 @@ allprojects {
     }
 }
 
+// Prettier handles the file types ktlint does not: Markdown, YAML, JSON, JS,
+// CSS and HTML. It is configured once on the root project (rather than per
+// subproject) so the whole repository is covered by a single Node/Prettier run,
+// and it is left on Prettier's defaults so there is no house style to maintain.
+spotless {
+    format("prettier") {
+        target(
+            "**/*.md",
+            "**/*.yml",
+            "**/*.yaml",
+            "**/*.json",
+            "**/*.js",
+            "**/*.css",
+            "**/*.html"
+        )
+        targetExclude("**/build/**", "**/node_modules/**")
+        prettier()
+    }
+}
+
 detekt {
     config.setFrom(file("${project.rootDir}/config/detekt/detekt.yml"))
     buildUponDefaultConfig = true

--- a/composeApp/src/webMain/resources/index.html
+++ b/composeApp/src/webMain/resources/index.html
@@ -1,27 +1,73 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
- <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How old am I</title>
-  <meta property="og:title" content="年齢の計算">
-  <meta property="og:description" content="生年月日から年齢を計算するWebアプリ">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="https://raw.githubusercontent.com/yu-ko-ba/how-old-am-i/main/composeApp/src/wasmJsMain/resources/icons/icon-384x384.png">
-  <meta name="theme-color" content="#FFF8F5" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#19120C" media="(prefers-color-scheme: dark)">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link type="text/css" rel="stylesheet" href="styles.css">
-  <script type="application/javascript" src="registerServiceWorker.js"></script>
-  <link rel="manifest" href="manifest.json">
- </head>
- <body style="text-align: center; align-content: center">
-  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 50 50" role="presentation">
-   <circle cx="25" cy="25" r="20" stroke="#ccc" stroke-width="4" fill="none" />
-   <circle cx="25" cy="25" r="20" stroke="#333" stroke-width="4" fill="none" stroke-linecap="round" stroke-dasharray="90 125">
-    <animateTransform attributeName="transform" type="rotate" from="0 25 25" to="360 25 25" dur="1s" repeatCount="indefinite" />
-   </circle>
-  </svg>
-  <script type="application/javascript" src="composeApp.js"></script>
- </body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>How old am I</title>
+    <meta property="og:title" content="年齢の計算" />
+    <meta
+      property="og:description"
+      content="生年月日から年齢を計算するWebアプリ"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/yu-ko-ba/how-old-am-i/main/composeApp/src/wasmJsMain/resources/icons/icon-384x384.png"
+    />
+    <meta
+      name="theme-color"
+      content="#FFF8F5"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#19120C"
+      media="(prefers-color-scheme: dark)"
+    />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link type="text/css" rel="stylesheet" href="styles.css" />
+    <script
+      type="application/javascript"
+      src="registerServiceWorker.js"
+    ></script>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body style="text-align: center; align-content: center">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="40"
+      height="40"
+      viewBox="0 0 50 50"
+      role="presentation"
+    >
+      <circle
+        cx="25"
+        cy="25"
+        r="20"
+        stroke="#ccc"
+        stroke-width="4"
+        fill="none"
+      />
+      <circle
+        cx="25"
+        cy="25"
+        r="20"
+        stroke="#333"
+        stroke-width="4"
+        fill="none"
+        stroke-linecap="round"
+        stroke-dasharray="90 125"
+      >
+        <animateTransform
+          attributeName="transform"
+          type="rotate"
+          from="0 25 25"
+          to="360 25 25"
+          dur="1s"
+          repeatCount="indefinite"
+        />
+      </circle>
+    </svg>
+    <script type="application/javascript" src="composeApp.js"></script>
+  </body>
 </html>

--- a/composeApp/src/webMain/resources/registerServiceWorker.js
+++ b/composeApp/src/webMain/resources/registerServiceWorker.js
@@ -1,15 +1,16 @@
 (() => {
-    if ("serviceWorker" in navigator) {
-        window.addEventListener("load", () => {
-            navigator.serviceWorker.register("serviceWorker.js")
-                .then((registration) => {
-                    console.log("Service Worker registerd!");
-                    console.log(`scope: ${registration.scope}`);
-                })
-                .catch((error) => {
-                    console.log("Service Worker register failed");
-                    console.log(`error: ${error}`);
-                });
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker
+        .register("serviceWorker.js")
+        .then((registration) => {
+          console.log("Service Worker registerd!");
+          console.log(`scope: ${registration.scope}`);
+        })
+        .catch((error) => {
+          console.log("Service Worker register failed");
+          console.log(`error: ${error}`);
         });
-    }
+    });
+  }
 })();

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1,11 +1,12 @@
-html, body {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 textarea {
-    width: 28px;
+  width: 28px;
 }

--- a/composeApp/workbox-config-for-wasm.js
+++ b/composeApp/workbox-config-for-wasm.js
@@ -1,8 +1,10 @@
 module.exports = {
-    globDirectory: "build/dist/wasmJs/productionExecutable/",
-    globPatterns: ["**/*.{html,css,js,json,png,jpg,jpeg,svg,gif,webp,ico,ttf,woff,woff2,wasm,cvr}"],
-    maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
-    skipWaiting: true,
-    clientsClaim: true,
-    swDest: "build/dist/wasmJs/productionExecutable/serviceWorker.js",
+  globDirectory: "build/dist/wasmJs/productionExecutable/",
+  globPatterns: [
+    "**/*.{html,css,js,json,png,jpg,jpeg,svg,gif,webp,ico,ttf,woff,woff2,wasm,cvr}",
+  ],
+  maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
+  skipWaiting: true,
+  clientsClaim: true,
+  swDest: "build/dist/wasmJs/productionExecutable/serviceWorker.js",
 };

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -6,12 +6,12 @@
 naming:
   FunctionNaming:
     # Jetpack Compose functions use PascalCase by design.
-    ignoreAnnotated: ['Composable', 'Preview']
+    ignoreAnnotated: ["Composable", "Preview"]
     # The default test excludes enumerate the test source sets but miss
     # `wasmJsTest`; this pattern covers every test source set instead.
-    excludes: ['**/test/**', '**/*Test/**']
+    excludes: ["**/test/**", "**/*Test/**"]
 
 style:
   MagicNumber:
     # Same `wasmJsTest` gap as above; do not flag literals in test code.
-    excludes: ['**/test/**', '**/*Test/**']
+    excludes: ["**/test/**", "**/*Test/**"]


### PR DESCRIPTION
## Summary

Adds [Prettier](https://prettier.io/) to the project so the file types ktlint
doesn't cover — Markdown, YAML, JSON, JS, CSS and HTML — are formatted
consistently.

Prettier is wired in through Spotless's built-in Prettier support rather than a
standalone Node toolchain. Because the project already runs
`./gradlew spotlessCheck` in CI, Prettier is covered by that existing job — no
new workflow, no new dependency in the version catalog.

Following a "fit to standard" approach, the setup keeps configuration to a
minimum:

- **No `.prettierrc`.** Prettier's defaults are used as-is, so there is no house
  style to maintain or bikeshed.
- Configured **once on the root project** so a single Prettier run covers the
  whole repository, with `build/` and `node_modules/` excluded.

## Changes

- `build.gradle.kts`: add a `format("prettier")` Spotless step.
- Everything else in the diff is the mechanical reformat produced by
  `./gradlew spotlessApply` (whitespace, indentation and quote style only — no
  behavioural changes).

## How it runs in CI

Spotless invokes Prettier via Node, which is preinstalled on GitHub's
`ubuntu-latest` runners, so the existing **Check Formatting** job picks it up
without any workflow edits.

## Verification

- `./gradlew spotlessApply` — formats the files.
- `./gradlew spotlessCheck` — passes and is idempotent.

## Usage

- `./gradlew spotlessApply` — auto-format all files (Kotlin + Prettier).
- `./gradlew spotlessCheck` — verify formatting, as CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W3eHGepyiZjHwy6SpTaHy

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3eHGepyiZjHwy6SpTaHy)_