### PR TITLE
ci: add actionlint workflow linting job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
       - name: Run Detekt
         run: ./gradlew detekt
 
+  actionlint:
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color
+
   tests:
     name: Run Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a dedicated actionlint job to the CI workflow so GitHub Actions
workflow files are statically checked. It runs as an independent job
alongside the existing formatting, static analysis, tests, and build
jobs, so it executes in parallel rather than gating them.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P5xBLdSUgnRJYhtdMcxEaX