### PR TITLE
ci: authenticate the JetBrains JDK download on GitHub

### DIFF
--- a/.github/actions/build-distribution/action.yml
+++ b/.github/actions/build-distribution/action.yml
@@ -7,14 +7,8 @@ description: >
 runs:
   using: composite
   steps:
-    - name: Setup JDK
-      uses: actions/setup-java@v5
-      with:
-        java-version: "21"
-        distribution: "jetbrains"
-
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+    - name: Setup build
+      uses: ./.github/actions/setup-build
 
     - name: Export Library Definitions
       shell: bash

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,23 @@
+name: Setup build
+description: >
+  Sets up the JDK and Gradle toolchain shared by every job that runs Gradle in
+  this repository, so the toolchain is configured identically everywhere.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: "21"
+        distribution: "jetbrains"
+      # The JetBrains distribution resolves its version by paging through the
+      # JetBrainsRuntime releases via the GitHub API, and reads the credential
+      # from $GITHUB_TOKEN rather than the action's `token` input. Without this
+      # the requests are anonymous and share the 60 req/hour/IP limit with every
+      # other runner on the same address, which intermittently fails the job.
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "jetbrains"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
       - name: Run Spotless
         run: ./gradlew spotlessCheck
       - name: Check version catalog formatting
@@ -39,13 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "jetbrains"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
       - name: Run Detekt
         run: ./gradlew detekt
 
@@ -70,13 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "jetbrains"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
       - name: Run Tests
         run: ./gradlew allTests
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,11 +16,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Not ./.github/actions/setup-build: dependency-submission sets Gradle up
+      # itself, so this job needs the JDK alone. See that action for why the
+      # JetBrains distribution needs GITHUB_TOKEN.
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "jetbrains"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Send dependencies to Dependabot
         uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -46,14 +46,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "jetbrains"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       - name: Regenerate yarn.lock
         run: ./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock


### PR DESCRIPTION
## Why

The `Update yarn.lock` job on #79 failed at **Setup JDK**:

```
Trying to resolve the latest version from remote
##[error]Java setup process failed due to: API rate limit exceeded for 20.102.223.151.
```

The `jetbrains` distribution of `actions/setup-java` resolves its version by paging through the JetBrainsRuntime releases via the GitHub API, and it reads its credential from `$GITHUB_TOKEN` — **not** from the action's `token` input ([installer.ts](https://github.com/actions/setup-java/blob/main/src/distributions/jetbrains/installer.ts)):

```ts
const bearerToken = process.env.GITHUB_TOKEN;
...
if (bearerToken) requestHeaders['Authorization'] = `Bearer ${bearerToken}`;
```

That is why the failing run logged `token: ***` and still made anonymous requests, sharing the 60 req/hour/IP limit with every other runner on the same address. The listing is paginated at `per_page=100`, so each job spends several requests on it.

Every job that builds this repository ran the same unauthenticated setup, so this could have surfaced in any of them, not just the one that happened to fail. It has already been seen intermittently on `Static Analysis` and `Run Tests`.

## What changed

All six `actions/setup-java` call sites were unauthenticated. A new `setup-build` composite action holds the shared JDK + Gradle setup and passes the token, and is used everywhere the two are set up together:

| File | Change |
| --- | --- |
| `.github/actions/setup-build/action.yml` | New — `setup-java` (with `GITHUB_TOKEN`) + `setup-gradle` |
| `.github/workflows/ci.yml` (×3) | Replaced with `setup-build` |
| `.github/workflows/update-yarn-lock.yml` | Replaced with `setup-build` |
| `.github/actions/build-distribution/action.yml` | Replaced with `setup-build` |
| `.github/workflows/dependabot.yml` | Kept its own JDK step, `GITHUB_TOKEN` added inline |

`dependabot.yml` is deliberately left out of the composite action: `gradle/actions/dependency-submission` sets Gradle up itself, so routing it through `setup-build` would run `setup-gradle` redundantly. The reason is recorded in a comment there.

Modelled on the same fix in [ComposePWA](https://github.com/yuyuyuyuyu-dev/ComposePWA/blob/main/.github/actions/setup-build/action.yml).

## Test plan

- [ ] `actionlint` passes — verified locally with 1.7.12 (CI pins 1.7.7), exit 0
- [ ] Only two `setup-java` call sites remain, both with `GITHUB_TOKEN`: `grep -rn "setup-java" -A8 .github/`
- [ ] This PR's own CI is green — it exercises `setup-build` through `ci.yml` (Check Formatting, Static Analysis, Run Tests) and through the nested `build-distribution` (Build Distribution)

`Update yarn.lock` does not run on this PR (it is gated on `github.actor == 'dependabot[bot]'` and on `gradle/libs.versions.toml` changing), so it is covered indirectly by the `setup-build` path the other jobs exercise.

## Note for after merge

`update-yarn-lock.yml` checks out `ref: ${{ github.head_ref }}`, i.e. the PR branch itself, and a local composite action is resolved from that workspace. An **existing Dependabot PR that has not been rebased** will therefore not contain `.github/actions/setup-build` and its `Update yarn.lock` job will fail to find the action.

Only #79 is affected. Merge this first, then `@dependabot rebase` on #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)