### PR TITLE
fix(build): stop js and wasm yarn installs from racing each other

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinToolingSetupTask
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -8,6 +11,27 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.versionCatalogUpdate)
 }
+
+// The js and wasmJs targets each register their own npm install and tooling
+// setup task on the root project, and nothing orders them against each other,
+// so Gradle is free to run them at the same time. They all shell out to yarn,
+// which serialises concurrent invocations behind one global mutex — that is the
+// recurring "Waiting for the other yarn instance to finish (<pid>)" in CI logs.
+// A loser of that race can return without having installed its workspace, and
+// jsBrowserTest then fails with
+//   Cannot find node module "kotlin-web-helpers/dist/kotlin-test-karma-runner.js"
+// because build/js/packages/*-test was never populated. Letting yarn arbitrate
+// is what makes this flaky, so hand every yarn-invoking task a build service
+// that admits one user at a time and keep a single yarn process alive at once.
+abstract class YarnSerializationService : BuildService<BuildServiceParameters.None>
+
+val yarnSerialization =
+    gradle.sharedServices.registerIfAbsent("yarnSerialization", YarnSerializationService::class) {
+        maxParallelUsages.set(1)
+    }
+
+tasks.withType<KotlinNpmInstallTask>().configureEach { usesService(yarnSerialization) }
+tasks.withType<KotlinToolingSetupTask>().configureEach { usesService(yarnSerialization) }
 
 allprojects {
     apply(plugin = "com.diffplug.spotless")


### PR DESCRIPTION
## Why

`Run Tests` fails intermittently with:

```
Execution failed for task ':composeApp:jsBrowserTest'
> Cannot find node module "kotlin-web-helpers/dist/kotlin-test-karma-runner.js"
  in ".../build/js/packages/HowOldAmI-composeApp-test"
```

Most recently on #79, where a plain re-run went green with no code change.

### Root cause

The `js` and `wasmJs` targets each register their own npm install and tooling setup task on the **root** project, and nothing orders them against each other, so Gradle runs them concurrently. All of them shell out to yarn, which serialises concurrent invocations behind a single global mutex.

The failing run's log shows all three contending on one yarn process (pid 2268):

```
07:32:27.65  > Task :kotlinWasmToolingSetup            (yarn pid 2268)
07:32:28.75  warning Waiting for the other yarn instance to finish (2268)
             > Task :kotlinNpmInstall
07:32:34.95  warning Waiting for the other yarn instance to finish (2268)
             > Task :kotlinWasmNpmInstall
07:33:56.24  > Task :composeApp:jsBrowserTest FAILED
07:34:11.04  <pid 2268 finally reports its install>
```

`:kotlinNpmInstall` returned **without ever installing its workspace**: the failing run contains no `workspace-aggregator ... > HowOldAmI-composeApp` yarn output at all, while passing runs do. So `build/js/packages/*-test` was left unpopulated and the test could not resolve `kotlin-web-helpers`.

This is pre-existing, not a recent regression — `Waiting for the other yarn instance` appears in **every** CI run so far, including green ones and on `main`. It only breaks the build when the js install happens to be the loser.

## What changed

Gate every yarn-invoking task on a build service that admits one user at a time, so at most one yarn process is ever alive.

Task types were confirmed against the actual task graph rather than assumed — the three yarn-invoking tasks are exactly `:kotlinNpmInstall`, `:kotlinWasmNpmInstall` (`KotlinNpmInstallTask`) and `:kotlinWasmToolingSetup` (`KotlinToolingSetupTask`), matching the three contenders in the log above.

A build service was chosen over a `mustRunAfter` chain because it is ordering-agnostic and needs no change when a target is added or the plugin reshuffles these tasks.

## Test plan

- [x] `./gradlew allTests` on a clean `build/js` + `build/wasm` + `composeApp/build` — succeeds, and both `jsBrowserTest` and `wasmJsBrowserTest` actually execute
- [x] Zero `Waiting for the other yarn instance` warnings in that run
- [x] Configuration cache still reused (`Configuration cache entry reused.`), so the service is CC-compatible
- [x] Build service verified attached to all three tasks, read back from the task graph: `services=[yarnSerialization, ...]`
- [x] `./gradlew spotlessApply` produces no diff; `./gradlew detekt` passes
- [ ] CI is green on this PR

### Signal to watch after merge

`Waiting for the other yarn instance to finish` should **disappear** from CI logs. Since it currently appears in 100% of runs, its absence is a direct confirmation that the serialisation took effect — this PR's own `Run Tests` log is the first check of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)